### PR TITLE
Fixed issue with mixed up variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ var result = scrypt.hashSync(key,{"N":16,"r":1,"p":1},64,"");
 console.log(result.toString("hex"));
 
 //Asynchronous
-scrypt.hash(key, {"N":16,"r":1,"p":1},64,"", function(err, res) {
+scrypt.hash(key, {"N":16,"r":1,"p":1},64,"", function(err, result) {
   console.log(result.toString("hex"));
 });
 


### PR DESCRIPTION
The console.log printed out `result`, but `result` had not been declared locally inside the function. The callback function took in `err, res` of which `res` never got used in the function body. The logged `result` was then accessing the global variable `result` defined on line 242.
I was going to change the `console.log(result.toString("hex"))` to  `console.log(res.toString("hex"))`, but the other examples use `result` so I changed the parameter to be consistent with the rest of the examples.