### PR TITLE
Bugfix for `params()` and `paramsSync()` argument ordering of `maxmem…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.0.?] - 2017-12-28
+### Fixed
+- Bugfix for `params()` and `paramsSync()` argument ordering of `maxmem` and `maxmemfrac` to match documentation.
+
 ## [6.0.2] - 2016-04-17
 ### Fixed
 - Microsoft compile issues

--- a/src/node-boilerplate/inc/scrypt_params_async.h
+++ b/src/node-boilerplate/inc/scrypt_params_async.h
@@ -33,8 +33,8 @@ class ScryptParamsAsyncWorker : public ScryptAsyncWorker {
     ScryptParamsAsyncWorker(Nan::NAN_METHOD_ARGS_TYPE info) :
       ScryptAsyncWorker(new Nan::Callback(info[4].As<v8::Function>())),
       maxtime(info[0]->NumberValue()),
-      maxmemfrac(info[1]->NumberValue()),
-      maxmem(info[2]->IntegerValue()),
+      maxmemfrac(info[2]->NumberValue()),
+      maxmem(info[1]->IntegerValue()),
       osfreemem(info[3]->IntegerValue())
     {
       logN = 0;

--- a/src/node-boilerplate/scrypt_params_sync.cc
+++ b/src/node-boilerplate/scrypt_params_sync.cc
@@ -23,8 +23,8 @@ NAN_METHOD(paramsSync) {
   // Arguments from JavaScript
   //
   const double maxtime = info[0]->NumberValue();
-  const size_t maxmem = info[2]->IntegerValue();
-  const double maxmemfrac = info[1]->NumberValue();
+  const size_t maxmem = info[1]->IntegerValue();
+  const double maxmemfrac = info[2]->NumberValue();
   const size_t osfreemem = info[3]->IntegerValue();
 
   //

--- a/tests/scrypt-tests.js
+++ b/tests/scrypt-tests.js
@@ -223,6 +223,18 @@ describe("Scrypt Node Module Tests", function() {
         });
       }
     });
+
+    describe("Sanity check results of paramSync calls", function() {
+      it("Should return p>1 for a 4MB maxmem limit and 10s maxtime", function() {
+        var params = scrypt.paramsSync(10, Math.pow(2, 22));
+        expect(params.p).to.be.above(1);
+      });
+
+      it("Should return p==1 for a 32MB maxmem limit and 0.001s maxtime", function() {
+        var params = scrypt.paramsSync(0.001, Math.pow(2, 25));
+        expect(params.p).to.be.equal(1);
+      });
+    });
   });
 
   describe("Scrypt KDF Function", function() {


### PR DESCRIPTION
…` and `maxmemfrac` to match documentation

Documentation lists the argument order of `scrypt.paramsSync` and
`scrypt.params` as `maxtime, [maxmem, [max_memfrac]]`, and the argument
checking in `index.js` is consistent with this. However, both
`src/node-boilerplate/inc/scrypt_params_async.h` and
`src/node-boilerplate/scrypt_params_sync.cc` were accessing the arguments as
`[maxtime, max_memfrac, maxmem]`, and thus returning incorrect results.